### PR TITLE
feat: added snyk scan to pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,19 @@
 version: 2.1
 
+orbs:
+  snyk: snyk/snyk@1.7.0
+
 jobs:
   install:
     docker:
       - image: cimg/node:20.3.1
     steps:
       - run: npm ci
+      - snyk/scan
 
 workflows:
   build-and-deploy:
     jobs:
-      - install
+      - install:
+          context:
+            - snyk-security


### PR DESCRIPTION
This PR is kindly created for you by SnykMe
- Adds the latest Snyk orb to the CircleCI configuration so that it is available for the pipeline
- Adds the snyk/scan command after installation and testing of the project
- Adds a context called "snyk-security" to the workflow job that is running the snyk/scan command
- The PR should only add the snyk/scan step into a single job
- The PR should preserve all existing circleci contexts
- If the snyk orb is already present, update it to version snyk/snyk@1.7.0